### PR TITLE
Replace package ID in manifest for consistency

### DIFF
--- a/Unity-Tests/2022.3.62f3/Packages/manifest.json
+++ b/Unity-Tests/2022.3.62f3/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "file:./../../../Unity-Package/Assets/root",
+    "YOUR_PACKAGE_ID_LOWERCASE": "file:./../../../Unity-Package/Assets/root",
     "com.unity.feature.development": "1.0.1",
     "com.unity.test-framework": "1.1.33",
     "com.unity.ugui": "1.0.0",

--- a/Unity-Tests/2023.2.22f1/Packages/manifest.json
+++ b/Unity-Tests/2023.2.22f1/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "file:./../../../Unity-Package/Assets/root",
+    "YOUR_PACKAGE_ID_LOWERCASE": "file:./../../../Unity-Package/Assets/root",
     "com.unity.feature.development": "1.0.2",
     "com.unity.test-framework": "1.3.9",
     "com.unity.ugui": "2.0.0",

--- a/Unity-Tests/6000.3.1f1/Packages/manifest.json
+++ b/Unity-Tests/6000.3.1f1/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.ivanmurzak.unity.mcp": "file:./../../../Unity-Package/Assets/root",
+    "YOUR_PACKAGE_ID_LOWERCASE": "file:./../../../Unity-Package/Assets/root",
     "com.unity.feature.development": "1.0.1",
     "com.unity.ide.visualstudio": "2.0.25",
     "com.unity.test-framework": "1.6.0",


### PR DESCRIPTION
Update the package ID in the manifest.json files to ensure consistency across different Unity test versions.