### PR TITLE
Enable TestAssemblies and UNITY_INCLUDE_TESTS

### DIFF
--- a/Unity-Package/Assets/root/Tests/Editor/YOUR_PACKAGE_ID.Editor.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Editor/YOUR_PACKAGE_ID.Editor.Tests.asmdef
@@ -5,8 +5,6 @@
         "com.IvanMurzak.Unity.MCP.Editor.Tests",
         "com.IvanMurzak.Unity.MCP.Runtime",
         "com.IvanMurzak.Unity.MCP.TestFiles",
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
         "YOUR_PACKAGE_ID.Runtime",
         "YOUR_PACKAGE_ID.Editor"
     ],
@@ -14,10 +12,10 @@
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "System.Text.Json.dll",
         "Microsoft.Extensions.Logging.Abstractions.dll",
         "Microsoft.AspNetCore.SignalR.Client.dll",
@@ -28,7 +26,9 @@
         "R3.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Unity-Package/Assets/root/Tests/Runtime/YOUR_PACKAGE_ID.Tests.asmdef
+++ b/Unity-Package/Assets/root/Tests/Runtime/YOUR_PACKAGE_ID.Tests.asmdef
@@ -4,15 +4,14 @@
         "com.IvanMurzak.Unity.MCP.Runtime",
         "com.IvanMurzak.Unity.MCP.Tests",
         "com.IvanMurzak.Unity.MCP.TestFiles",
-        "UnityEngine.TestRunner",
         "YOUR_PACKAGE_ID.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "nunit.framework.dll",
         "System.Text.Json.dll",
         "Microsoft.Extensions.Logging.Abstractions.dll",
         "Microsoft.AspNetCore.SignalR.Client.dll",

--- a/Unity-Tests/2022.3.62f3/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/2022.3.62f3/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2022.3.62f3/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/2022.3.62f3/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2022.3.62f3/Packages/manifest.json
+++ b/Unity-Tests/2022.3.62f3/Packages/manifest.json
@@ -44,5 +44,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["YOUR_PACKAGE_ID_LOWERCASE"]
 }

--- a/Unity-Tests/2023.2.22f1/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/2023.2.22f1/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2023.2.22f1/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/2023.2.22f1/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/2023.2.22f1/Packages/manifest.json
+++ b/Unity-Tests/2023.2.22f1/Packages/manifest.json
@@ -47,5 +47,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["YOUR_PACKAGE_ID_LOWERCASE"]
 }

--- a/Unity-Tests/6000.3.1f1/Assets/EditorTests/EditorTests.asmdef
+++ b/Unity-Tests/6000.3.1f1/Assets/EditorTests/EditorTests.asmdef
@@ -1,19 +1,15 @@
 {
     "name": "EditorTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/6000.3.1f1/Assets/RuntimeTests/RuntimeTests.asmdef
+++ b/Unity-Tests/6000.3.1f1/Assets/RuntimeTests/RuntimeTests.asmdef
@@ -1,17 +1,13 @@
 {
     "name": "RuntimeTests",
     "rootNamespace": "",
-    "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner"
-    ],
+    "references": [],
     "includePlatforms": [],
     "excludePlatforms": [],
+    "optionalUnityReferences": ["TestAssemblies"],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "nunit.framework.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
         "UNITY_INCLUDE_TESTS"

--- a/Unity-Tests/6000.3.1f1/Packages/manifest.json
+++ b/Unity-Tests/6000.3.1f1/Packages/manifest.json
@@ -48,5 +48,6 @@
         "org.nuget"
       ]
     }
-  ]
+  ],
+  "testables": ["YOUR_PACKAGE_ID_LOWERCASE"]
 }


### PR DESCRIPTION
Update test asmdef files to use Unity's TestAssemblies and test define instead of hardcoded test runner/NUnit refs. Removed references to "UnityEngine.TestRunner"/"UnityEditor.TestRunner" and "nunit.framework.dll", cleared/emptied precompiled references where applicable, added "optionalUnityReferences": ["TestAssemblies"], and set the "UNITY_INCLUDE_TESTS" define constraint. Also added "testables": ["YOUR_PACKAGE_ID_LOWERCASE"] to the test projects' Packages/manifest.json so the package is visible to tests. Affects Unity-Package/Assets/root/Tests and Unity-Tests/*/{versions}/Assets/* asmdef and manifest files.