### PR TITLE
ci: add disk cleanup step to test workflow

### DIFF
--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -56,7 +56,20 @@ jobs:
           lfs: false
 
       # --------------------------------------------------------------------- #
-      # 2-c. Cache & run the Unity test-runner
+      # 2-c. Free disk space
+      # --------------------------------------------------------------------- #
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      # --------------------------------------------------------------------- #
+      # 2-d. Cache & run the Unity test-runner
       # --------------------------------------------------------------------- #
       - uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Summary
- Added `jlumbroso/free-disk-space` step to `test_unity_plugin.yml` to free disk space before Unity tests run
- Mirrors the same change from IvanMurzak/Unity-MCP#620
- Prevents out-of-space failures on GitHub Actions runners

Closes #4

## Test plan
- [ ] CI runs successfully with the new cleanup step
- [ ] Verify disk space is freed before Unity test-runner executes