### PR TITLE
ci: add disk cleanup step to CI workflows

### DIFF
--- a/.github/workflows/release.yml-sample
+++ b/.github/workflows/release.yml-sample
@@ -47,6 +47,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Cache Unity Library
         uses: actions/cache@v5
         with:

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -59,7 +59,7 @@ jobs:
       # 2-c. Free disk space
       # --------------------------------------------------------------------- #
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: false
           android: true


### PR DESCRIPTION
## Summary
- Pin `jlumbroso/free-disk-space` to `v1.3.1` (was `@main`) in `test_unity_plugin.yml`
- Add `free-disk-space` step to `release.yml-sample` `build-unity-installer` job, after checkout and before cache/build steps
- Frees disk space on CI runners before Unity tests and builds run

Closes #6

## Test plan
- [ ] Verify `test_unity_plugin.yml` uses `jlumbroso/free-disk-space@v1.3.1` (not `@main`)
- [ ] Verify `release.yml-sample` has the `Free disk space` step in `build-unity-installer` between checkout and cache
- [ ] Run a test workflow to confirm the disk cleanup step executes without errors