### PR TITLE
chore: purge org.nuget scopes (installer, fixtures, manifests)

### DIFF
--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Installer.Manifest.cs
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Installer.Manifest.cs
@@ -34,10 +34,6 @@ namespace YOUR_PACKAGE_ID.Installer
         public static readonly string[] PackageIds = new string[] {
             "com.ivanmurzak",            // Ivan Murzak's OpenUPM packages
             "extensions.unity",          // Ivan Murzak's OpenUPM packages (older)
-            "org.nuget.com.ivanmurzak",  // Ivan Murzak's NuGet packages
-            "org.nuget.microsoft",       // Microsoft NuGet packages
-            "org.nuget.system",          // Microsoft NuGet packages
-            "org.nuget.r3"               // R3 package NuGet package
         };
 
         /// <summary>

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/Correct/correct_manifest.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/Correct/correct_manifest.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [
@@ -22,11 +11,7 @@
       "url": "https://package.openupm.com",
       "scopes": [
         "com.ivanmurzak",
-        "extensions.unity",
-        "org.nuget.com.ivanmurzak",
-        "org.nuget.microsoft",
-        "org.nuget.system",
-        "org.nuget.r3"
+        "extensions.unity"
       ]
     }
   ]

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopedregistries_empty_1.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopedregistries_empty_1.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": []

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopedregistries_empty_2.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopedregistries_empty_2.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": []

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopedregistries_gone.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopedregistries_gone.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   }
 }

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_empty.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_empty.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_gone.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_gone.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_1.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_1.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [
@@ -22,10 +11,7 @@
       "url": "https://package.openupm.com",
       "scopes": [
         "com.ivanmurzak",
-        "extensions.unity",
-        "org.nuget.com.ivanmurzak",
-        "org.nuget.microsoft",
-        "org.nuget.system"
+        "extensions.unity"
       ]
     }
   ]

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_2.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_2.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [
@@ -22,9 +11,7 @@
       "url": "https://package.openupm.com",
       "scopes": [
         "com.ivanmurzak",
-        "extensions.unity",
-        "org.nuget.com.ivanmurzak",
-        "org.nuget.microsoft"
+        "extensions.unity"
       ]
     }
   ]

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_3.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_3.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [
@@ -22,8 +11,7 @@
       "url": "https://package.openupm.com",
       "scopes": [
         "com.ivanmurzak",
-        "extensions.unity",
-        "org.nuget.com.ivanmurzak"
+        "extensions.unity"
       ]
     }
   ]

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_4.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_4.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [

--- a/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_5.json
+++ b/Installer/Assets/YOUR_PACKAGE_NAME Installer/Tests/Files/scopes_partial_5.json
@@ -3,17 +3,6 @@
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.1.33",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
-    "org.nuget.microsoft.aspnetcore.signalr.client": "9.0.7",
-    "org.nuget.microsoft.aspnetcore.signalr.protocols.json": "9.0.7",
-    "org.nuget.microsoft.bcl.memory": "9.0.7",
-    "org.nuget.microsoft.codeanalysis.csharp": "4.13.0",
-    "org.nuget.microsoft.extensions.caching.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.dependencyinjection.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting": "9.0.7",
-    "org.nuget.microsoft.extensions.hosting.abstractions": "9.0.7",
-    "org.nuget.microsoft.extensions.logging.abstractions": "9.0.7",
-    "org.nuget.r3": "1.3.0",
-    "org.nuget.system.text.json": "9.0.7",
     "PACKAGE_ID": "PACKAGE_VERSION"
   },
   "scopedRegistries": [

--- a/Unity-Package/Packages/manifest.json
+++ b/Unity-Package/Packages/manifest.json
@@ -21,13 +21,11 @@
       "url": "https://package.openupm.com",
       "scopes": [
         "com.ivanmurzak",
-        "extensions.unity",
-        "org.nuget.com.ivanmurzak",
-        "org.nuget.microsoft",
-        "org.nuget.system",
-        "org.nuget.r3"
+        "extensions.unity"
       ]
     }
   ],
-  "testables": ["com.ivanmurzak.unity.mcp"]
+  "testables": [
+    "com.ivanmurzak.unity.mcp"
+  ]
 }


### PR DESCRIPTION
Purge all `org.nuget*` OpenUPM scopes (NuGet DLLs are vendored under Assets/Plugins/NuGet, so these scopes are unused). Removes them from the Installer `PackageIds`, the 11 installer test fixtures + `correct_manifest.json`, and the Unity-Package project manifest. JSON rewritten via json.dumps(indent=2), byte-identical to the installer SimpleJSON output — so the installer EditMode test (release.yml, Linux LF runner) stays green. Validated locally: only a Windows CRLF-vs-LF artifact differs; content is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)