### PR TITLE
Release: Unity-MCP 0.82.3 cascade

### DIFF
--- a/Unity-Package/Packages/YOUR_PACKAGE_ID_LOWERCASE/package.json
+++ b/Unity-Package/Packages/YOUR_PACKAGE_ID_LOWERCASE/package.json
@@ -13,7 +13,7 @@
     "unity": "2022.3",
     "description": "Some description",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.82.2"
+        "com.ivanmurzak.unity.mcp": "0.82.3"
     },
     "scopedRegistries": [
         {

--- a/Unity-Package/Packages/manifest.json
+++ b/Unity-Package/Packages/manifest.json
@@ -13,7 +13,7 @@
     "com.unity.modules.unitywebrequestaudio": "1.0.0",
     "com.unity.modules.unitywebrequesttexture": "1.0.0",
     "com.unity.modules.unitywebrequestwww": "1.0.0",
-    "com.ivanmurzak.unity.mcp": "0.82.2"
+    "com.ivanmurzak.unity.mcp": "0.82.3"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
Automated release cascade for [Unity-MCP 0.82.3](https://github.com/IvanMurzak/Unity-MCP/releases/tag/0.82.3).

- Bumps the `com.ivanmurzak.unity.mcp` dependency to `0.82.3`.
- Patch-bumps this extension's own version (skipped for Unity-AI-Tools-Template).
- When the release changed bundled NuGet DLLs: refreshes `Assets/Plugins/NuGet/` drops and per-Unity-version `.meta` files across Unity-Package and Unity-Tests projects.

Merge only after every check is green (enforced by the branch ruleset). Opened by the unity-mcp/plugin release pipeline (iteration 03b).