### PR TITLE
chore(ci): upgrade Node20-deprecated actions to Node24-capable versions

### DIFF
--- a/.github/workflows/release.yml-sample
+++ b/.github/workflows/release.yml-sample
@@ -413,7 +413,7 @@ jobs:
           ls -la ./assets
 
       - name: Create Tag and Release with all assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.check-version-tag.outputs.version }}
           name: ${{ needs.check-version-tag.outputs.version }}
@@ -436,21 +436,21 @@ jobs:
     if: always()
     steps:
       - name: Delete Unity Package artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: unity-installer-package
           failOnError: false
         continue-on-error: true
 
       - name: Delete signed UPM package artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: signed-upm-package
           failOnError: false
         continue-on-error: true
 
       - name: Delete release notes artifacts
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: release-notes
           failOnError: false

--- a/.github/workflows/test_unity_plugin.yml
+++ b/.github/workflows/test_unity_plugin.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           lfs: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Check version consistency


### PR DESCRIPTION
These actions' pinned majors are the last Node20-based releases and are
already being force-run on Node 24. Bump to the Node24-capable majors.

- actions/setup-python        @v5 -> @v6  (x1, test_unity_plugin.yml)
- geekyeggo/delete-artifact   @v5 -> @v6  (x3, release.yml-sample)
- softprops/action-gh-release @v2 -> @v3  (x1, release.yml-sample)

The `*.yml-sample` workflows are intentionally disabled template files;
the version pins inside them are fixed but they remain disabled (no
rename, no trigger changes).

Not changed: actions/cache@v5 (already past the dead v3-era SHA pin),
game-ci/* (already on a node24 SHA/major), mukunku/tag-exists-action@v1.7.0
(already Node24), and all other actions outside the upgrade map.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WxMrEo6Nk4RCQZjA4LkFC
