### PR TITLE
Release: Unity-MCP 0.86.0 cascade

### DIFF
--- a/Unity-Package/Packages/YOUR_PACKAGE_ID_LOWERCASE/package.json
+++ b/Unity-Package/Packages/YOUR_PACKAGE_ID_LOWERCASE/package.json
@@ -13,7 +13,7 @@
     "unity": "2022.3",
     "description": "Some description",
     "dependencies": {
-        "com.ivanmurzak.unity.mcp": "0.85.1"
+        "com.ivanmurzak.unity.mcp": "0.86.0"
     },
     "scopedRegistries": [
         {

--- a/Unity-Tests/2022.3.62f3/Packages/packages-lock.json
+++ b/Unity-Tests/2022.3.62f3/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.85.1",
+      "version": "0.86.0",
       "depth": 0,
       "source": "local",
       "dependencies": {

--- a/Unity-Tests/2023.2.22f1/Packages/packages-lock.json
+++ b/Unity-Tests/2023.2.22f1/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.85.1",
+      "version": "0.86.0",
       "depth": 0,
       "source": "local",
       "dependencies": {

--- a/Unity-Tests/6000.3.1f1/Packages/packages-lock.json
+++ b/Unity-Tests/6000.3.1f1/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ivanmurzak.unity.mcp": {
-      "version": "0.85.1",
+      "version": "0.86.0",
       "depth": 0,
       "source": "local",
       "dependencies": {


### PR DESCRIPTION
Automated release cascade for [Unity-MCP 0.86.0](https://github.com/IvanMurzak/Unity-MCP/releases/tag/0.86.0).

- Bumps the `com.ivanmurzak.unity.mcp` dependency to `0.86.0`.
- Patch-bumps this extension's own version (skipped for Unity-AI-Tools-Template).
- When the release changed bundled NuGet DLLs: refreshes `Assets/Plugins/NuGet/` drops and per-Unity-version `.meta` files across Unity-Package and Unity-Tests projects.

Merge only after every check is green (enforced by the branch ruleset). Opened by the unity-mcp/plugin release pipeline (iteration 03b).